### PR TITLE
A word-based integer encoding approach.

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
@@ -217,8 +217,8 @@ private func maxDecimalExponentAndPowerForUnsignedIntegerWord() -> (exponent: UI
 ///
 private func maxDecimalDigitCountForUnsignedInteger(bitWidth: Int) -> Int {
     // - Int.init(some BinaryFloatingPoint) rounds to zero.
-    // - log10(2.0) is overestimated: 0.301029995663981⌈19.....⌉.
     // - Double.init(exactly:) and UInt.init(_:) for correctness.
+    // - log10(2.0) is: 1.0011010001000001001101⌈01...⌉ * 2^(-2).
     return Int(Double(exactly: UInt(bitWidth))! * log10(2.0)) + 1
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
@@ -208,15 +208,20 @@ private func maxDecimalExponentAndPowerForUnsignedIntegerWord() -> (exponent: UI
     return (exponent: exponent, power: power)
 }
 
-/// The maximum [number of decimal digits][number-of-digits] needed the represent
-/// an unsigned integer with the given `bitWidth`.
+/// The maximum [number of decimal digits][algorithm] needed the represent an unsigned integer
+/// with the given `bitWidth`.
 ///
 /// - Parameter bitWidth: The unsigned binary integer's bit width.
 ///
-/// [number-of-digits]: https://www.exploringbinary.com/number-of-decimal-digits-in-a-binary-integer
+/// ### Development
+///
+/// It rounds up and uses `Double.init(exactly:)` as a rounding error precaution, which limits
+/// the `bitWidth` to `0...pow(2, 53)`. This value is an upper bound, and it need not be exact.
+///
+/// [algorithm]: https://www.exploringbinary.com/number-of-decimal-digits-in-a-binary-integer
 ///
 private func maxDecimalDigitCountForUnsignedInteger(bitWidth: Int) -> Int {
-    Int((Double(UInt(bitWidth)) * log10(2)).rounded(.down)) + 1
+    Int((Double(exactly: UInt(bitWidth))! * log10(2)).rounded(.up)) + 1
 }
 
 // MARK: - BinaryInteger + Parsing

--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
@@ -94,8 +94,8 @@ words: UnsafeMutableBufferPointer<UInt>, isSigned: Bool) -> ArraySlice<UInt8> {
     }
     
     let radix: (exponent: UInt, power: UInt) = maxDecimalExponentAndPowerForUnsignedIntegerWord()
-    let capacity: Int = maxDecimalDigitCountForUnsignedInteger(bitWidth: max(1, words.count * UInt.bitWidth)) + (isLessThanZero ? 1 : 0)
-    var ascii = ContiguousArray(repeating: UInt8(ascii: "0"), count: capacity) // Fills the array with ASCII zeros (see later steps).
+    let capacity =  maxDecimalDigitCountForUnsignedInteger(bitWidth: words.count * UInt.bitWidth) + (isLessThanZero ? 1 : 0)
+    var ascii = ContiguousArray(repeating: UInt8(ascii: "0"), count: capacity) // Sets initial ASCII zeros (see later steps).
     
     var wordsIndex = words.endIndex
     var writeIndex = ascii.endIndex
@@ -208,20 +208,18 @@ private func maxDecimalExponentAndPowerForUnsignedIntegerWord() -> (exponent: UI
     return (exponent: exponent, power: power)
 }
 
-/// The maximum [number of decimal digits][algorithm] needed the represent an unsigned integer
-/// with the given `bitWidth`.
-///
-/// - Parameter bitWidth: The unsigned binary integer's bit width.
-///
-/// ### Development
-///
-/// It rounds up and uses `Double.init(exactly:)` as a rounding error precaution, which limits
-/// the `bitWidth` to `0...pow(2, 53)`. This value is an upper bound, and it need not be exact.
+/// Returns an upper bound for the [number of decimal digits][algorithm] needed
+/// to represent an unsigned integer with the given `bitWidth`.
 ///
 /// [algorithm]: https://www.exploringbinary.com/number-of-decimal-digits-in-a-binary-integer
 ///
+/// - Parameter bitWidth: The unsigned binary integer's bit width.
+///
 private func maxDecimalDigitCountForUnsignedInteger(bitWidth: Int) -> Int {
-    Int((Double(exactly: UInt(bitWidth))! * log10(2)).rounded(.up)) + 1
+    // - Int.init(some BinaryFloatingPoint) rounds to zero.
+    // - log10(2.0) is overestimated: 0.301029995663981⌈19.....⌉.
+    // - Double.init(exactly:) and UInt.init(_:) for correctness.
+    return Int(Double(exactly: UInt(bitWidth))! * log10(2.0)) + 1
 }
 
 // MARK: - BinaryInteger + Parsing

--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
@@ -43,250 +43,182 @@ extension BinaryInteger {
 // MARK: - BinaryInteger + Numeric string representation
 
 extension BinaryInteger {
-    /// Formats `self` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html) which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
-    ///
-    /// This produces output that (at time of writing) looks identical to the `description` for many `BinaryInteger` types, such as the built-in integer types.  However, the format of `description` is not specifically defined by `BinaryInteger` (or anywhere else, really), and as such cannot be relied upon.  Thus this purpose-built method, instead.
-    internal var numericStringRepresentation: ArraySlice<UInt8> {
-        // It might be worth moving this method into the Swift standard library one day, so that it can be used as the basis for the default `description` instead of duplicating that conversion process.  At least while `description`'s output happens to match this one's.
-        //
-        // This property's type is an ArraySlice rather than a straight ContiguousArray because it's computationally more expensive to size the array exactly right (whether by pre-calculating the required size more precisely, or by dynamically resizing it during execution of the iterative algorithm).  Since this is intended to only be a transient value, for the purposes of translating from BinaryInteger to the ICU libraries, this is the right compromise of runtime speed (CPU time) and memory efficiency (it's usually only off by a byte or two, if that).
-
-        // Fast-path for values that fit into a UInt, as the conversion to a UInt should be virtually free if it's possible (it's essentially just self.words[0]) and there's a specialisation of this function for UInt that's faster.
-        if let fastForm = UInt(exactly: self) {
-            return fastForm.numericStringRepresentation
-        }
-
-        precondition(.zero != self, "Value of zero (for self) should have been handled by fast path, but wasn't.") // Zero isn't handled correctly in the algorithm below (no numbers will actually be emitted) because it's more work to do so, which is unnecessary as the fast path above should handle that case.
-
-        // The algorithm here is conceptually fairly simple.  In a nutshell, the value of self is broken down into Word-sized chunks, each of which is divided by ten repeatedly until the value dimishes to zero.  The remainder of each division is the next digit of the result (starting with the least significant).
-        //
-        // A conceptually simpler approach is to skip the first step of breaking things into Word-sized chunks, and just do the division by 10 on the whole value of `self`.  The difference is performance - native integer division (for machine-word-sized integers) is essentially O(1), whereas division of arbitrary-precision integers is essentially O(log2(bitWidth)) since it's composed of _multiple_ machine-word-sized divides proportionate to its binary magnitude.
-        //
-        // So we replace some of those expensive O(log2(bitWidth)) divides with simpler O(1) divides, by first dividing by the largest multiple of ten such that the remainder fits in a single machine word (UInt), and then using regular integer division CPU instructions to further divide that simple machine-word-sized remainder down into individual digits.
-
-        let (decimalDigitsPerWord, wordMagnitude) = Self.decimalDigitsAndMagnitudePerWord()
-        let negative = 0 > self
-        let maximumDigits = (Self.maximumDecimalDigitsForUnsigned(bitWidth: self.magnitudeBitWidth)
-                             + (negative ? 1 : 0)) // Include room for "-" prefix if necessary.
-        var actualDigits: Int = Int.min // Actually initialised inside the closure below, but the compiler mistakenly demands a default value anyway.
-
-        return ContiguousArray<UInt8>(unsafeUninitializedCapacity: maximumDigits) { buffer, initialisedCount in
-            var tmp = self
-            var wordInsertionPoint = buffer.endIndex - 1
-
-            while .zero != tmp {
-                let (quotient, remainder) = tmp.quotientAndRemainder(dividingBy: wordMagnitude)
-                precondition(.zero == remainder || (negative == (0 > remainder)), "Starting value \(tmp) is \(negative ? "negative" : "positive (or zero)") yet the remainder of division by \(wordMagnitude) is not: \(remainder).  quotientAndRemainder(dividingBy:) is not implemented correctly for \(type(of: self)) (it might be using F-division instead of T-division).") // It's an entirely understandable error for an implementor to use F-division for their integer quotient and remainder, but they're supposed to use T-division.  i.e. the quotient is supposed to be rounded towards zero rather than down (and that effects the modulus correspondingly, since either way the results must satisfy r = d ⨉ (r idiv i) + (r mod i)).  T-division is convenient because its remainder is neatly the value of interest to this algorithm, rather than being offset by the divisor if r is negative.  While it would be technically possible to assume F-division if the remainder's sign doesn't match, the incorrect implementation of quotientAndRemainder(dividingBy:) will probably still break other algorithms and so we shouldn't encourage it.
-
-                // By definition the remainder has to be a single word (since the divisor, `wordMagnitude`, fits in a single word), so we can avoid working on a BinaryInteger generically and just use the first word directly, which is concretely UInt.
-                assert(remainder.magnitudeBitWidth <= Words.Element.bitWidth,
-                       "The remainder of dividing \(tmp) by \(wordMagnitude), \(remainder), should fit into a single word, yet it does not (its magnitude bit width is \(remainder.magnitudeBitWidth) which is greater than the \(Words.Element.bitWidth) bits of Words.Element (\(Words.Element.self))).")
-                var word = remainder.words.first ?? 0
-
-                if negative {
-                    // Luckily for us `words` is defined to be in two's complement form, so we can manually flip the sign.  This doesn't normally work because two's complement cannot represent the positive version of its most negative value, but we know we won't have that here because it's the remainder from division by `wordMagnitude`, which is always going to be less than UInt.max because `wordMagnitude` itself has to fit into UInt (and the remainder of division is always at least one smaller than the divisor).
-                    // Note that for a word of zero (no remainder) this does technically overflow but it's intentional - zero is special since there's no distinct representation for -0 vs +0, but ~UInt(0) &+ 1 is 0, conveniently!  So we can trade a conditional (for avoiding this block if `word` is .zero) for two trivial arithmetic instructions.
-                    word = ~word &+ 1
-                }
-
-                let digitsAdded = word.numericStringRepresentation(intoEndOfBuffer: &buffer[...wordInsertionPoint])
-
-                if .zero != quotient { // Not on the last word, so need to fill in leading zeroes etc.
-                    wordInsertionPoint -= decimalDigitsPerWord
-
-                    let leadingZeroes = decimalDigitsPerWord - digitsAdded
-                    assert(0 <= leadingZeroes, "Negative leading zeroes \(leadingZeroes)!  Expected \(decimalDigitsPerWord) digits per word and added \(digitsAdded).")
-
-                    if 0 < leadingZeroes {
-                        buffer[(wordInsertionPoint + 1)...(wordInsertionPoint + leadingZeroes)].initialize(repeating: UInt8(ascii: "0"))
-                    }
-                } else {
-                    wordInsertionPoint -= digitsAdded
-                }
-
-                tmp = quotient
-            }
-
-            if negative {
-                buffer[wordInsertionPoint] = UInt8(ascii: "-")
-                wordInsertionPoint -= 1
-            }
-
-            actualDigits = wordInsertionPoint.distance(to: buffer.endIndex) - 1
-
-            let unusedDigits = maximumDigits - actualDigits
-            assert(0 <= unusedDigits, "Negative unused digits \(unusedDigits)!  Expected at most \(maximumDigits) digit(s) but emitted \(actualDigits).")
-
-            if 0 < unusedDigits {
-                buffer[0..<unusedDigits].initialize(repeating: 0) // The buffer is permitted to be partially uninitialised, but only at the end.  So we have to initialise the unused portion at the start, in principle.  Technically this probably doesn't matter given we never subsequently read this part of the buffer, but there's no way to express that such that the compiler can ensure it for us.
-            }
-
-            initialisedCount = maximumDigits
-        }[(maximumDigits - actualDigits)...]
-    }
     
-    /// - Parameter bitWidth: The bit width of interest.  Must be zero or positive.
-    /// - Returns: The maximum number of decimal digits that an unsigned value of the given bit width may contain.
-    internal static func maximumDecimalDigitsForUnsigned(bitWidth: Int) -> Int {
-        guard 0 < bitWidth else { return 0 }
-        guard 1 != bitWidth else { return 1 } // Algorithm below only works for bit widths of _two_ and above.
-
-        return Int((Double(bitWidth) * log10(2)).rounded(.up)) + 1 // https://www.exploringbinary.com/number-of-decimal-digits-in-a-binary-integer
-    }
-    
-    /// The bit width of the magnitude of `self`.
+    /// Formats `self` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html)
+    /// which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
     ///
-    /// This is useful for determining how many bits are needed to store the magnitude of `self` (an unsigned integer) _without_ actually determining the magnitude (via the `magnitude` property) since that is relatively expensive (in memory if not also runtime, depending on the size and implementation of the underlying type).
+    /// This produces output that (at time of writing) looks identical to the `description` for
+    /// many `BinaryInteger` types, such as the built-in integer types.  However, the format of
+    /// `description` is not specifically defined by `BinaryInteger` (or anywhere else, really),
+    /// and as such cannot be relied upon.  Thus this purpose-built method, instead.
     ///
-    /// It is never less than one.
-    internal var magnitudeBitWidth: Int {
-        // `BinaryInteger` does provide a `bitWidth` property which could be used to help with this, but for three things:
-        //
-        //   1. For `FixedWidthInteger`s it returns the fixed (maximum) size of the type, not the (minimum) size required to represent `self`.
-        //
-        //   2. It returns the size of the value in two's complement representation, which includes the sign bit that we don't care about.  But we can't just subtract one from that value [for signed types], because for negative powers of two the signed form is one bit shorter than the [unsigned] magnitude's (signed types can represent -(2^N) through +(2^N)-1 - note the asymmetry).  That special case can technically be handled, but it requires determining if `self` is a negative power of two which is relatively expensive for large `BinaryInteger`s.
-        //
-        //   3. Some `BinaryInteger` implementations implement `bitWidth` wrong, due to its terse and ambiguous documentation.  e.g. some are also `FixedWidthInteger`s yet _don't_ return the maximum bit width of the type (or vice versa), some have off-by-one errors for negative powers of two, etc.  Although it's not this code's responsibility to allow for implementation errors, it's nice to.
-        //
-        // So, it's both necessary and preferable (respectively) to just examine `words` directly.
-
-        if .zero == self {
-            return 1
-        } else if .zero <= self {
-            // Find the highest-order word with any bits set, determine the overall index of the highest set bit, and return that plus one (index to count conversion).
-
-            for (i, word) in words.reversed().enumerated() {
-                if .zero != word {
-                    let fullWidth = type(of: word).bitWidth
-                    return ((words.count - i - 1) * fullWidth) + (fullWidth - word.leadingZeroBitCount)
-                }
-            }
-
-            preconditionFailure("\(type(of: self)) \(self) compared as not zero yet all its words are zero.")
-        } else { // `self` is negative.
-            // Perform two's complement one word at a time, keeping track of the index of the highest set bit seen so far.  After enumerating all the words, return that index plus one (index to count conversion).
-
-            var carryingOne = true // Covers both the initial +1 (as part of two's complement) and overflow between words.
-            var indexOfHighestSetBitSeenSoFar = 0
-
-            for (i, word) in words.enumerated() {
-                var positiveWord = ~word
-
-                if carryingOne {
-                    (positiveWord, carryingOne) = positiveWord.addingReportingOverflow(1)
-                }
-
-                let fullWidth = type(of: word).bitWidth
-
-                if carryingOne {
-                    indexOfHighestSetBitSeenSoFar += fullWidth
-                } else if .zero != positiveWord {
-                    indexOfHighestSetBitSeenSoFar = (fullWidth * i) + (fullWidth - positiveWord.leadingZeroBitCount) - 1
-                }
-            }
-
-            return indexOfHighestSetBitSeenSoFar + 1
-        }
-    }
-
-    /// Determines the magnitude (the largest decimal magnitude that fits in Word, e.g. 100 for UInt8) and "maximum" digits per word (e.g. two for UInt8).
-    ///
-    /// Note that 'maximum' in this case is context-specific to the `numericStringRepresentation` algorithm.  It is not necessarily the maximum digits required for _any_ Word, but rather any value of Word type which is less than the maximum decimal magnitude.  Typically this is one digit less.
-    internal // For unit test accessibility, otherwise would be fileprivate.
-    static func decimalDigitsAndMagnitudePerWord() -> (digits: Int, magnitude: Self) {
-        // This method cannot be defined statically because it depends on the types of both Self and Word.  The compiler can in principle fold this down to the resulting values at compile time - since it knows the concrete types for any given call site - and then just inline those into the caller.
-
-        // First, a fast-path that works for any type (for `Self`) which can (essentially) represent a UInt (or larger).
-        let guessDigits = Int(Double(Words.Element.bitWidth) * log10(2))
-        let guessMagnitude = pow(10, Double(guessDigits))
-
-        if let magnitudeAsSelf = Self(exactly: guessMagnitude) {
-            return (guessDigits, magnitudeAsSelf)
-        }
-
-        // Alas `Self` is smaller than UInt, so fall back to a truly generic - but slower - algorithm to find the results.  This is because BinaryIntegers - unlike e.g. FixedWidthIntegers - don't provide APIs for questions like "what is the maximum bit width of Self?".
-
-        var count = 1
-        var value: Words.Element = 1
-
-        while true {
-            var (nextValue, overflowed) = value.multipliedReportingOverflow(by: 10)
-
-            // Words.Element might be wider than the actual type, e.g. if Self is UInt8 (and UInt is not).  The magnitude is limited by the smallest of the two.
-            if !overflowed && nil == Self(exactly: nextValue) {
-                overflowed = true
-            }
-
-            if !overflowed || .zero == nextValue {
-                count += 1
-            }
-
-            if overflowed {
-                return (count - 1, Self(value))
-            }
-
-            value = nextValue
-        }
+    public var numericStringRepresentation: ArraySlice<UInt8> {
+        numericStringRepresentationForBinaryInteger(words: self.words, isSigned: Self.isSigned)
     }
 }
 
-extension UInt {
-    /// Formats `self` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html) which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
-    ///
-    /// This is intended to be used only by the `numericStringRepresentation` property (both the specialised form below and the generic one for all BinaryIntegers, above).  Prefer the `numericStringRepresentation` property for all other use-cases.
-    ///
-    /// - Parameter intoEndOfBuffer: The buffer to write into, which _must_ contain enough space for the result.  The formatted output is placed into the _end_ of this buffer ("right-aligned", if you will), though the output is numerically still left-to-right.  The contents of this buffer do not have to be pre-initialised.
-    /// - Returns: How many entries (UInt8s) of the buffer were used.  Note that zero is a valid return value, as nothing is written to the buffer if `self` is zero (this may be odd but it's acceptable to `numericStringRepresentation` and it simplifies the overall implementation).
-    fileprivate func numericStringRepresentation(intoEndOfBuffer buffer: inout Slice<UnsafeMutableBufferPointer<UInt8>>) -> Int {
-        guard .zero != self else { return 0 } // Easier to special-case this here than deal with it below (annoying off-by-one potential errors).
+// MARK: - BinaryInteger + Numeric string representation + Utilities
 
-        var insertionPoint = buffer.endIndex - 1
-        var tmp = self
+/// The maximum [number of decimal digits][number-of-digits] needed the represent
+/// an unsigned integer with the given `bitWidth`.
+///
+/// - Parameters:
+///    - bitWidth: The bit width of an unsigned integer, which must be nonnegative.
+///
+/// [number-of-digits]: https://www.exploringbinary.com/number-of-decimal-digits-in-a-binary-integer
+///
+private func maxDecimalDigitCountForUnsignedInteger(bitWidth: Int) -> Int {
+    Int((Double(UInt(bitWidth)) * log10(2)).rounded(.down)) + 1
+}
 
-        // Keep dividing by ten until the value disappears.  Each time we divide, we get one more digit for the output as the remainder of the division.  Since with this approach digits "pop off" from least significant to most, the output buffer is filled in reverse.
-        while .zero != tmp {
-            let (quotient, remainder) = tmp.quotientAndRemainder(dividingBy: 10)
-
-            buffer[insertionPoint] = UInt8(ascii: "0") + UInt8(remainder)
-
-            if .zero != quotient {
-                insertionPoint -= 1
-                assert(insertionPoint >= buffer.startIndex, "Buffer is too small (\(buffer.count) UInt8s) to contain the result.")
-            }
-
-            tmp = quotient
-        }
-
-        return insertionPoint.distance(to: buffer.endIndex)
+/// The largest `exponent` and `power` in `pow(10, exponent) <= UInt.max + 1`.
+///
+/// The `exponent` is also the maximum number of decimal digits needed to represent a binary integer
+/// in the range of `0 ..< power`. Another method is used to estimate the total number of digits, however.
+/// This is so that binary integers can be rabased and encoded in the same loop.
+///
+/// ```
+/// 32-bit: (exponent:  9, power:           1000000000)
+/// 64-bit: (exponent: 19, power: 10000000000000000000)
+/// ```
+///
+private func maxDecimalExponentAndPowerForUnsignedIntegerWord() -> (exponent: UInt, power: UInt) {
+    var exponent = 1 as UInt
+    var power = 0010 as UInt
+    
+    while true {
+        let next = power.multipliedReportingOverflow(by: 10)
+        if  next.overflow { break }
+        
+        exponent += 1
+        power = next.partialValue
     }
+    
+    return (exponent: exponent, power: power)
+}
 
-    /// Formats `self` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html) which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
-    ///
-    /// This specialisation (for UInt) is faster than the generic BinaryIntegers implementation (earlier in this file).  It is used as an opportunistic fast-path in the generic implementation, for any values that happen to fit into a UInt.
-    internal var numericStringRepresentation: ArraySlice<UInt8> {
-        // This property's type is an ArraySlice rather than a straight ContiguousArray because it's computationally more expensive to size the array exactly right (whether by pre-calculating the required size more precisely, or by dynamically resizing it during execution of the iterative algorithm).  Since this is intended to only be a transient value, for the purposes of translating from BinaryInteger to the ICU libraries, this is the right compromise of runtime speed (CPU time) and memory efficiency (usually just one excess byte, if any).
-
-        // It's easier to just special-case zero than handle it in the main algorithm.
-        guard .zero != self else {
-            return [UInt8(ascii: "0")]
-        }
-
-        let maximumDigits = Self.maximumDecimalDigitsForUnsigned(bitWidth: self.magnitudeBitWidth)
-        var actualDigits: Int = Int.min // Actually initialised inside the closure below, but the compiler mistakenly demands a default value anyway.
-
-        return ContiguousArray(unsafeUninitializedCapacity: maximumDigits) { buffer, initialisedCount in
-            actualDigits = numericStringRepresentation(intoEndOfBuffer: &buffer[...])
-
-            let unusedDigits = maximumDigits - actualDigits
-            assert(0 <= unusedDigits, "Negative unused digits \(unusedDigits)!  Expected at most \(maximumDigits) digit(s) but emitted \(actualDigits).")
-
-            if 0 < unusedDigits {
-                buffer[0..<unusedDigits].initialize(repeating: 0) // The buffer is permitted to be partially uninitialised, but only at the end.  So we have to initialise the unused portion at the start, in principle.  Technically this probably doesn't matter given we never subsequently read this part of the buffer, but there's no way to express that such that the compiler can ensure it for us.
-            }
-
-            initialisedCount = maximumDigits
-        }[(maximumDigits - actualDigits)...]
+/// Forms the `two's complement` of a binary integer's `words`.
+///
+/// - Parameters:
+///    - words: A mutable collection of binary integer words, ordered from least significant to most significant.
+///
+private func formTwosComplementForBinaryInteger(words: UnsafeMutableBufferPointer<UInt>) {
+    var carry =  true
+    for index in words.indices {
+        (words[index], carry) = (~words[index]).addingReportingOverflow(carry ? 1 : 0)
     }
+}
+
+/// Forms the `quotient` of dividing the `dividend` by the `divisor`, then returns the `remainder`.
+///
+/// - Parameters:
+///   - dividend: An unsigned binary integer's words.
+///   - divisor:  An unsigned binary integer's only word.
+///
+/// - Returns: The `remainder`, which is a value in the range of `0 ..< divisor`.
+///
+private func formQuotientWithRemainderForUnsignedInteger(
+words dividend: Slice<UnsafeMutableBufferPointer<UInt>>, dividingBy divisor: UInt) -> UInt {
+    var remainder = 0 as UInt
+    
+    for index in (dividend.startIndex ..< dividend.endIndex).reversed() {
+        (dividend.base[index], remainder) = divisor.dividingFullWidth((high: remainder, low: dividend.base[index]))
+    }
+    
+    return remainder
+}
+
+/// Writes `word` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html)  to
+/// the trailing edge of `buffer`, then returns the least significant `buffer` index written to.
+///
+/// - Parameters:
+///   - word: An unsigned binary integer's only word.
+///   - buffer: A buffer with enough memory to accommodate the format.
+///
+private func formTrailingNumericStringRepresentationForUnsignedInteger(
+word: UInt, into buffer: Slice<UnsafeMutableBufferPointer<UInt8>>) -> Int {
+    var magnitude = word
+    var index = buffer.endIndex
+    
+    repeat {
+        precondition(index > buffer.startIndex)
+        buffer.base.formIndex(before: &index)
+        
+        let remainder: UInt
+        (magnitude, remainder) = magnitude.quotientAndRemainder(dividingBy: 10)
+        buffer.base[index] = UInt8(ascii: "0") &+ UInt8(truncatingIfNeeded: remainder)
+    }   while magnitude != 0
+    
+    return index as Int
+}
+
+/// Formats `words` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html)
+/// which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
+///
+/// - Parameters:
+///   - words: The words of a binary integer.
+///   - isSigned: The signedness of a binary integer.
+///
+internal func numericStringRepresentationForBinaryInteger(
+words: some Collection<UInt>, isSigned: Bool) -> ArraySlice<UInt8> {
+    withUnsafeTemporaryAllocation(of: UInt.self, capacity: words.count) { copy in
+        // copies the words and then passes them to a non-generic, mutating, word-based algorithm
+        let count =  copy.initialize(fromContentsOf: words)
+        defer{ copy.baseAddress!.deinitialize(count: count) }
+        return numericStringRepresentationForMutableBinaryInteger(words: copy, isSigned: isSigned)
+    }
+}
+
+/// Formats `words` in "Numeric string" format (https://speleotrove.com/decimal/daconvs.html)
+/// which is the required input form for certain ICU functions (e.g. `unum_formatDecimal`).
+///
+/// - Parameters:
+///   - words: The mutable words of a binary integer.
+///   - isSigned: The signedness of a binary integer.
+///
+/// This method consumes the `words` such that the buffer is filled with zeros when it returns.
+///
+private func numericStringRepresentationForMutableBinaryInteger(
+words: UnsafeMutableBufferPointer<UInt>, isSigned: Bool) -> ArraySlice<UInt8> {
+    //  negative values are in two's complement form
+    let isLessThanZero = isSigned && Int(bitPattern: words.last ?? 0) < 0
+    if  isLessThanZero {
+        // forms the magnitude when it is less than zero
+        formTwosComplementForBinaryInteger(words: words)
+    }
+    
+    let radix =  maxDecimalExponentAndPowerForUnsignedIntegerWord()  as (exponent: UInt,  power: UInt)
+    let capacity = maxDecimalDigitCountForUnsignedInteger(bitWidth:  max(1, words.count * UInt.bitWidth)) + (isLessThanZero ? 1 : 0)
+    var ascii = ContiguousArray<UInt8>(repeating: UInt8(ascii: "0"), count: capacity) // fills the array with zeros (see later step)
+    
+    var wordsIndex = words.endIndex
+    var writeIndex = ascii.endIndex
+    var asciiIndex = ascii.endIndex
+    
+    ascii.withUnsafeMutableBufferPointer { ascii in
+        repeat {
+            // mutating buffer division prevents unnecessary allocations
+            let remainder = formQuotientWithRemainderForUnsignedInteger(words: words.prefix(upTo: wordsIndex), dividingBy: radix.power)
+            // the quotient is normalized for flexible-width performance
+            wordsIndex = words.prefix(upTo: wordsIndex).reversed().drop(while:{ $0 == 0 }).startIndex.base
+            // the remainder's numeric string representation is written to the array's trailing edge, up to the index
+            writeIndex = formTrailingNumericStringRepresentationForUnsignedInteger(word: remainder, into: ascii.prefix(upTo: asciiIndex))
+            // because the array is pre-filled with zeros, we can skip ahead. only the final loop's zeros are trimmed
+            asciiIndex = asciiIndex - Int(bitPattern: radix.exponent)
+            // the loop is done when the previously formed quotient is empty
+        }   while wordsIndex > words.startIndex
+        
+        asciiIndex = writeIndex // branchlessly trims the final loop's zeros
+        
+        //  adds a minus sign when less than zero
+        if  isLessThanZero {
+            ascii.formIndex(before:  &asciiIndex)
+            ascii[asciiIndex] = UInt8(ascii: "-")
+        }
+    }
+    
+    assert(words.allSatisfy({ $0 == 0 }))
+    return ascii.suffix(from: asciiIndex) as ArraySlice<UInt8>
 }
 
 // MARK: - BinaryInteger + Parsing

--- a/Tests/FoundationInternationalizationTests/Formatting/Number/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/Number/BinaryInteger+FormatStyleTests.swift
@@ -47,8 +47,8 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
 
     func testNumericStringRepresentation_builtinIntegersAroundDecimalMagnitude() throws {
         func check<I: FixedWidthInteger>(type: I.Type = I.self, magnitude: String, oneLess: String, oneMore: String) {
-            let mag = I.decimalDigitsAndMagnitudePerWord().magnitude
-
+            var mag = I(1); while !mag.multipliedReportingOverflow(by: 10).overflow { mag *= 10 }
+            
             checkNSR(value: mag, expected: magnitude)
             checkNSR(value: mag - 1, expected: oneLess)
             checkNSR(value: mag + 1, expected: oneMore)
@@ -129,124 +129,95 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
     }
 #endif
 #endif // canImport(Numberick) || canImport(BigInt)
+}
 
-    func testMagnitudeBitWidth_builtinIntegers() {
-        XCTAssertEqual(1, 0.magnitudeBitWidth)
-        XCTAssertEqual(1, (0 as UInt).magnitudeBitWidth)
-
-        // Fixed-width unsigned
-        XCTAssertEqual(1, (1 as UInt).magnitudeBitWidth)
-        XCTAssertEqual(2, (2 as UInt).magnitudeBitWidth)
-        XCTAssertEqual(2, (3 as UInt).magnitudeBitWidth)
-        XCTAssertEqual(3, (4 as UInt).magnitudeBitWidth)
-
-        XCTAssertEqual(64, UInt64.max.magnitudeBitWidth)
-        XCTAssertEqual(1, UInt64.min.magnitudeBitWidth)
-
-        // Fixed-width signed
-        XCTAssertEqual(1, 1.magnitudeBitWidth)
-        XCTAssertEqual(2, 2.magnitudeBitWidth)
-        XCTAssertEqual(2, 3.magnitudeBitWidth)
-        XCTAssertEqual(3, 4.magnitudeBitWidth)
-
-        XCTAssertEqual(1, (-1).magnitudeBitWidth)
-        XCTAssertEqual(2, (-2).magnitudeBitWidth)
-        XCTAssertEqual(2, (-3).magnitudeBitWidth)
-        XCTAssertEqual(3, (-4).magnitudeBitWidth)
-
-        XCTAssertEqual(63, Int64.max.magnitudeBitWidth)
-        XCTAssertEqual(64, Int64.min.magnitudeBitWidth)
-        XCTAssertEqual(63, (Int64.min + 1).magnitudeBitWidth)
+final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
+    
+    // MARK: Tests
+    
+    func testMinMax32() {
+        check(integer:  Int32.min,       expectation: "-2147483648")
+        check(integer:  Int32.max,       expectation:  "2147483647")
+        check(integer: UInt32.min,       expectation:           "0")
+        check(integer: UInt32.max/2,     expectation:  "2147483647")
+        check(integer: UInt32.max/2 + 1, expectation:  "2147483648")
+        check(integer: UInt32.max,       expectation:  "4294967295")
     }
-
-#if canImport(Numberick)
-    func testMagnitudeBitWidth_largeIntegers() {
-        // Unsigned
-        XCTAssertEqual(128, UInt128.max.magnitudeBitWidth)
-        XCTAssertEqual(64, UInt128(UInt64.max).magnitudeBitWidth)
-        XCTAssertEqual(1, UInt128.min.magnitudeBitWidth)
-        XCTAssertEqual(1, UInt128.zero.magnitudeBitWidth)
-
-        // Signed
-        XCTAssertEqual(127, Int128.max.magnitudeBitWidth)
-        XCTAssertEqual(63, Int128(Int64.max).magnitudeBitWidth)
-        XCTAssertEqual(3, Int128(4).magnitudeBitWidth)
-        XCTAssertEqual(2, Int128(3).magnitudeBitWidth)
-        XCTAssertEqual(2, Int128(2).magnitudeBitWidth)
-        XCTAssertEqual(1, Int128(1).magnitudeBitWidth)
-        XCTAssertEqual(1, Int128.zero.magnitudeBitWidth)
-        XCTAssertEqual(1, Int128(-1).magnitudeBitWidth)
-        XCTAssertEqual(2, Int128(-2).magnitudeBitWidth)
-        XCTAssertEqual(2, Int128(-3).magnitudeBitWidth)
-        XCTAssertEqual(3, Int128(-4).magnitudeBitWidth)
-        XCTAssertEqual(128, Int128.min.magnitudeBitWidth)
+    
+    func testTopBot32() {
+        check(integer:  Int32(bitPattern: 0xfffefdfc), expectation:     "-66052")
+        check(integer:  Int32(bitPattern: 0x03020100), expectation:   "50462976")
+        check(integer: UInt32(            0xfffefdfc), expectation: "4294901244")
+        check(integer: UInt32(            0x03020100), expectation:   "50462976")
     }
-#endif
-
-#if canImport(BigInt)
-    func testMagnitudeBitWidth_arbitraryPrecisionIntegers() {
-        // Arbitrary-precision unsigned
-        XCTAssertEqual(64, BigUInt(UInt64.max).magnitudeBitWidth)
-        XCTAssertEqual(1, BigUInt(UInt64.min).magnitudeBitWidth)
-
-        // Arbitrary-precision signed
-        XCTAssertEqual(63, BigInt(Int64.max).magnitudeBitWidth)
-        XCTAssertEqual(64, BigInt(Int64.min).magnitudeBitWidth)
-
-        // Signed & unsigned for multi-word numbers.
-        func checkBigInts(hexString: some StringProtocol, magnitudeBitWidth: Int) {
-            XCTAssertEqual(magnitudeBitWidth, BigUInt(hexString, radix: 16)!.magnitudeBitWidth)
-            XCTAssertEqual(magnitudeBitWidth, BigInt(hexString, radix: 16)!.magnitudeBitWidth)
-            XCTAssertEqual(magnitudeBitWidth, BigInt("-" + hexString, radix: 16)!.magnitudeBitWidth)
-        }
-
-        checkBigInts(hexString: "10000000000000000", magnitudeBitWidth: 65)
-        checkBigInts(hexString: "10000000000000001", magnitudeBitWidth: 65)
-        checkBigInts(hexString: "1ffffffffffffffff", magnitudeBitWidth: 65)
-        checkBigInts(hexString: "20000000000000000", magnitudeBitWidth: 66)
-        checkBigInts(hexString: "7fffffffffffffffffffffffffffffff", magnitudeBitWidth: 127)
-        checkBigInts(hexString: "80000000000000000000000000000000", magnitudeBitWidth: 128)
-        checkBigInts(hexString: "8fffffffffffffffffffffffffffffff", magnitudeBitWidth: 128)
-        checkBigInts(hexString: "100000000000000000000000000000000", magnitudeBitWidth: 129)
+    
+    func testMinMax64() {
+        check(integer:  Int64.min,       expectation: "-9223372036854775808")
+        check(integer:  Int64.max,       expectation:  "9223372036854775807")
+        check(integer: UInt64.min,       expectation:                    "0")
+        check(integer: UInt64.max/2,     expectation:  "9223372036854775807")
+        check(integer: UInt64.max/2 + 1, expectation:  "9223372036854775808")
+        check(integer: UInt64.max,       expectation: "18446744073709551615")
     }
-#endif
-
-    func check<I: BinaryInteger>(type: I.Type = I.self, digits: Int, magnitude: UInt) {
-        let actual = I.decimalDigitsAndMagnitudePerWord()
-
-        let maxDigits = [32: 9, 64: 19][UInt.bitWidth]!
-        let maxMagnitude: UInt = [32: 1_000_000_000, 64: 10_000_000_000_000_000_000][UInt.bitWidth]!
-
-        XCTAssertEqual(actual.digits, min(digits, maxDigits))
-        XCTAssertEqual(actual.magnitude, I(exactly: min(magnitude, maxMagnitude)))
+    
+    func testTopBot64() {
+        check(integer:  Int64(bitPattern: 0xfffefdfcfbfaf9f8), expectation:     "-283686952306184")
+        check(integer:  Int64(bitPattern: 0x0706050403020100), expectation:   "506097522914230528")
+        check(integer: UInt64(            0xfffefdfcfbfaf9f8), expectation: "18446460386757245432")
+        check(integer: UInt64(            0x0706050403020100), expectation:   "506097522914230528")
     }
-
-    func testDecimalDigitsAndMagnitudePerWord_builtinIntegers() throws {
-        check(type: Int8.self, digits: 2, magnitude: 100)
-        check(type: Int16.self, digits: 4, magnitude: 10_000)
-        check(type: Int32.self, digits: 9, magnitude: 1_000_000_000)
-        check(type: Int64.self, digits: 18, magnitude: 1_000_000_000_000_000_000)
-
-        check(type: UInt8.self, digits: 2, magnitude: 100)
-        check(type: UInt16.self, digits: 4, magnitude: 10_000)
-        check(type: UInt32.self, digits: 9, magnitude: 1_000_000_000)
-        check(type: UInt64.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
+    
+    func testMinMax128() {
+        check(x64:[ 0, ~0/2 + 1] as [UInt64], isSigned: true,  expectation: "-170141183460469231731687303715884105728") //  Int128.min
+        check(x64:[~0, ~0/2    ] as [UInt64], isSigned: true,  expectation:  "170141183460469231731687303715884105727") //  Int128.max
+        check(x64:[ 0,  0      ] as [UInt64], isSigned: false, expectation:                                        "0") // UInt128.min
+        check(x64:[~0, ~0/2    ] as [UInt64], isSigned: false, expectation:  "170141183460469231731687303715884105727") // UInt128.max/2
+        check(x64:[ 0, ~0/2 + 1] as [UInt64], isSigned: false, expectation:  "170141183460469231731687303715884105728") // UInt128.max/2 + 1
+        check(x64:[~0, ~0      ] as [UInt64], isSigned: false, expectation:  "340282366920938463463374607431768211455") // UInt128.max
     }
-
-#if canImport(Numberick)
-    func testDecimalDigitsAndMagnitudePerWord_largeIntegers() throws {
-        check(type: Int128.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
-        check(type: UInt128.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
-
-        check(type: Int256.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
-        check(type: UInt256.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
+    
+    func testTopBot128() {
+        check(x64:[0xf7f6f5f4f3f2f1f0, 0xfffefdfcfbfaf9f8] as [UInt64], isSigned: true,  expectation:     "-5233100606242806050955395731361296")
+        check(x64:[0x0706050403020100, 0x0f0e0d0c0b0a0908] as [UInt64], isSigned: true,  expectation:  "20011376718272490338853433276725592320")
+        check(x64:[0xf7f6f5f4f3f2f1f0, 0xfffefdfcfbfaf9f8] as [UInt64], isSigned: false, expectation: "340277133820332220657323652036036850160")
+        check(x64:[0x0706050403020100, 0x0f0e0d0c0b0a0908] as [UInt64], isSigned: false, expectation:  "20011376718272490338853433276725592320")
     }
-#endif
-
-#if canImport(BigInt)
-    func testDecimalDigitsAndMagnitudePerWord_arbitraryPrecisionIntegers() throws {
-        check(type: BigInt.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
-        check(type: BigUInt.self, digits: 19, magnitude: 10_000_000_000_000_000_000)
+    
+    func testWordsIsEmptyResultsInZero() {
+        check(words:[  ] as [UInt], isSigned: true,  expectation: "0")
+        check(words:[  ] as [UInt], isSigned: false, expectation: "0")
     }
-#endif
+    
+    func testSignExtendingDoesNotChangeTheResult() {
+        check(words:[ 0            ] as [UInt], isSigned: true,  expectation:  "0")
+        check(words:[ 0,  0        ] as [UInt], isSigned: true,  expectation:  "0")
+        check(words:[ 0,  0,  0    ] as [UInt], isSigned: true,  expectation:  "0")
+        check(words:[ 0,  0,  0,  0] as [UInt], isSigned: true,  expectation:  "0")
+        
+        check(words:[~0            ] as [UInt], isSigned: true,  expectation: "-1")
+        check(words:[~0, ~0        ] as [UInt], isSigned: true,  expectation: "-1")
+        check(words:[~0, ~0, ~0    ] as [UInt], isSigned: true,  expectation: "-1")
+        check(words:[~0, ~0, ~0, ~0] as [UInt], isSigned: true,  expectation: "-1")
+        
+        check(words:[ 0            ] as [UInt], isSigned: false, expectation:  "0")
+        check(words:[ 0,  0        ] as [UInt], isSigned: false, expectation:  "0")
+        check(words:[ 0,  0,  0    ] as [UInt], isSigned: false, expectation:  "0")
+        check(words:[ 0,  0,  0,  0] as [UInt], isSigned: false, expectation:  "0")
+    }
+    
+    // MARK: Assertions
+     
+    func check(integer: some BinaryInteger, expectation: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(integer.description, expectation, file: file, line: line)
+        check(words: Array(integer.words), isSigned: type(of: integer).isSigned, expectation: expectation, file: file, line: line)
+    }
+    
+    func check(x64: [UInt64], isSigned: Bool, expectation: String, file: StaticString = #file, line: UInt = #line) {
+        check(words: x64.flatMap(\.words), isSigned: isSigned, expectation: expectation, file: file, line: line)
+    }
+    
+    func check(words: [UInt], isSigned: Bool, expectation: String, file: StaticString = #file, line: UInt = #line) {
+        let ascii = numericStringRepresentationForBinaryInteger(words: words, isSigned: isSigned)
+        XCTAssertEqual(String(decoding: ascii, as: Unicode.ASCII.self), expectation, file: file, line: line)
+    }
 }

--- a/Tests/FoundationInternationalizationTests/Formatting/Number/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/Number/BinaryInteger+FormatStyleTests.swift
@@ -208,7 +208,8 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     // MARK: Assertions
      
     func check(integer: some BinaryInteger, expectation: String, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(integer.description, expectation, file: file, line: line)
+        XCTAssertEqual(integer.description, expectation,  file:  file, line: line)
+        check(ascii: integer.numericStringRepresentation, expectation: expectation, file: file, line: line)
         check(words: Array(integer.words), isSigned: type(of: integer).isSigned, expectation: expectation, file: file, line: line)
     }
     
@@ -218,6 +219,10 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     
     func check(words: [UInt], isSigned: Bool, expectation: String, file: StaticString = #file, line: UInt = #line) {
         let ascii = numericStringRepresentationForBinaryInteger(words: words, isSigned: isSigned)
+        check(ascii: ascii, expectation: expectation, file: file, line: line)
+    }
+    
+    func check(ascii: some Collection<UInt8>, expectation: String, file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(String(decoding: ascii, as: Unicode.ASCII.self), expectation, file: file, line: line)
     }
 }


### PR DESCRIPTION
Hi, I appreciate your work! 

I've spent some time on an alternative approach with measurements.

### Description

These changes aim to achieve two things. The first is making the algorithm non-generic, so DoubleWidth performs well. The second is performing mutating division, which makes arbitrary precision faster. Copying the binary integer's words to a temporary allocation achieves both. Since the algorithm takes a buffer pointer, it is also possible to test big integers without big integer models.

### Measurements

The tests were of the following shape, using T.max or T(UInt256.max).

<details>
<summary>Tests...</summary>

```swift
func testInt256() {
    var value = NBK.blackHoleIdentity(Int256.max) // T.max or T(UInt256.max) for flexible-width
    
    for _ in 0 ..< 250_000 {        
        // numberick:  NBK.blackHole(String(value, radix: 10))
        // stdlib:     NBK.blackHole(String(NBK.someSwiftBinaryInteger(value), radix: 10))
        // foundation: NBK.blackHole(String(bytes: value.numericStringRepresentation, encoding: .ascii))

        NBK.blackHoleInoutIdentity(&value)
    }
}
```

</details>

I have measured it as-is and with everything marked as `@inlinable`.

#### Summary

- ~~[U]Int[8-64]: makes little to no difference.~~
- NBKDoubleWidth: 40x faster when private, 1.3x faster when `@inlinable`.
- UIntXL (on feature branch): 5.8x faster when private, 3.1x faster when `@inlinable`.

#### Foundation: Current

|         | private | `@inlinable` |
|---------|---------|--------------|
| Int     |   0.061 |        0.045 | 
| UInt    |   0.053 |        0.046 | 
| Int256  |   5.272 |        0.097 | 
| UInt256 |   4.257 |        0.091 | 
| UIntXL  |   0.554 |        0.230 | 

#### Foundation: After Pull Request

|         | private | `@inlinable` |
|---------|---------|--------------|
| Int     |   0.057 |        0.040 |
| UInt    |   0.060 |        0.045 |
| Int256  |   0.122 |        0.070 |
| UInt256 |   0.120 |        0.072 |
| UIntXL  |   0.095 |        0.074 |

#### Points of Reference

|         | Stdlib | Numberick |
|---------|--------|-----------|
| Int     |  0.021 |     0.023 |
| UInt    |  0.022 |     0.022 |
| Int256  | 12.514 |     0.065 |
| UInt256 | 12.477 |     0.056 |
| UIntXL  |  3.992 |     0.058 |